### PR TITLE
test(bitcoind_rpc): Add ` common` module

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -17,12 +17,14 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
+# FIXME: (@leonardo) update the code to use corepc-node, and corepc-client instead and then remove this.
 bitcoincore-rpc = { version = "0.19.0" }
 bdk_core = { path = "../core", version = "0.6.1", default-features = false }
 
 [dev-dependencies]
 bdk_bitcoind_rpc = { path = "." }
-bdk_testenv = { path = "../testenv" }
+# FIXME: (@leonardo) update the code to use corepc-node, and corepc-client instead and then remove this.
+bdk_testenv = { version = "0.13.1" }
 bdk_chain = { path = "../chain" }
 
 [features]

--- a/crates/bitcoind_rpc/tests/common.rs
+++ b/crates/bitcoind_rpc/tests/common.rs
@@ -1,0 +1,20 @@
+use bdk_testenv::anyhow;
+use bdk_testenv::TestEnv;
+
+/// This trait is used for testing. It allows creating a new [`bitcoincore_rpc::Client`] connected
+/// to the instance of bitcoind running in the test environment. This way the `TestEnv` and the
+/// `Emitter` aren't required to share the same client. In the future when we no longer depend on
+/// `bitcoincore-rpc`, this can be updated to return the production client that is used by BDK.
+pub trait ClientExt {
+    /// Creates a new [`bitcoincore_rpc::Client`] connected to the current node instance.
+    fn get_rpc_client(&self) -> anyhow::Result<bitcoincore_rpc::Client>;
+}
+
+impl ClientExt for TestEnv {
+    fn get_rpc_client(&self) -> anyhow::Result<bitcoincore_rpc::Client> {
+        Ok(bitcoincore_rpc::Client::new(
+            &self.bitcoind.rpc_url(),
+            bitcoincore_rpc::Auth::CookieFile(self.bitcoind.workdir().join("regtest/.cookie")),
+        )?)
+    }
+}

--- a/crates/electrum/benches/test_sync.rs
+++ b/crates/electrum/benches/test_sync.rs
@@ -10,7 +10,7 @@ use bdk_core::{
     CheckPoint,
 };
 use bdk_electrum::BdkElectrumClient;
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::{anyhow, TestEnv};
 use criterion::{criterion_group, criterion_main, Criterion};
 use electrum_client::ElectrumApi;
 use std::{collections::BTreeSet, time::Duration};
@@ -77,7 +77,15 @@ pub fn test_sync_performance(c: &mut Criterion) {
     );
 
     // Setup receiver.
-    let genesis_cp = CheckPoint::new(0, env.bitcoind.client.get_block_hash(0).unwrap());
+    let genesis_cp = CheckPoint::new(
+        0,
+        env.bitcoind
+            .client
+            .get_block_hash(0)
+            .unwrap()
+            .block_hash()
+            .unwrap(),
+    );
 
     {
         let electrum_client =

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -8,17 +8,17 @@ use bdk_chain::{
 };
 use bdk_core::bitcoin::{
     key::{Secp256k1, UntweakedPublicKey},
-    Network,
+    Denomination, Txid,
 };
 use bdk_electrum::BdkElectrumClient;
 use bdk_testenv::{
     anyhow,
-    bitcoincore_rpc::{json::CreateRawTransactionInput, RawTx, RpcApi},
+    corepc_node::{Input, Output},
     TestEnv,
 };
 use core::time::Duration;
 use electrum_client::ElectrumApi;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 
 // Batch size for `sync_with_electrum`.
@@ -89,7 +89,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = BdkElectrumClient::new(electrum_client);
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
 
     // Get receiving address.
     let receiver_spk = get_test_spk();
@@ -100,48 +101,57 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
 
     // Select a UTXO to use as an input for constructing our test transactions.
     let selected_utxo = rpc_client
-        .list_unspent(None, None, None, Some(false), None)?
+        .list_unspent()?
+        .0
         .into_iter()
         // Find a block reward tx.
-        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
-        .expect("Must find a block reward UTXO");
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50).to_btc())
+        .expect("Must find a block reward UTXO")
+        .into_model()?;
 
     // Derive the sender's address from the selected UTXO.
-    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_spk = selected_utxo.script_pubkey.clone();
     let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
         .expect("Failed to derive address from UTXO");
 
     // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
-    let inputs = [CreateRawTransactionInput {
+    let inputs = [Input {
         txid: selected_utxo.txid,
-        vout: selected_utxo.vout,
+        vout: selected_utxo.vout as u64,
         sequence: None,
     }];
 
     // Create and sign the `send_tx` that sends funds to the receiver address.
-    let send_tx_outputs = HashMap::from([(
-        receiver_addr.to_string(),
-        selected_utxo.amount - SEND_TX_FEE,
-    )]);
-    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx_outputs = [Output::new(
+        receiver_addr,
+        selected_utxo.amount.to_unsigned()? - SEND_TX_FEE,
+    )];
     let send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &send_tx_outputs)?
+        .into_model()?
+        .0;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&send_tx)?
+        .into_model()?
+        .tx;
 
     // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
     // address.
-    let undo_send_outputs = HashMap::from([(
-        sender_addr.to_string(),
-        selected_utxo.amount - UNDO_SEND_TX_FEE,
-    )]);
-    let undo_send_tx =
-        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_outputs = [Output::new(
+        sender_addr,
+        selected_utxo.amount.to_unsigned()? - UNDO_SEND_TX_FEE,
+    )];
     let undo_send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &undo_send_outputs)?
+        .into_model()?
+        .0;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&undo_send_tx)?
+        .into_model()?
+        .tx;
 
     // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
-    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    let send_txid = env.rpc_client().send_raw_transaction(&send_tx)?.txid()?;
     env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -170,7 +180,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     // mempool.
     let undo_send_txid = env
         .rpc_client()
-        .send_raw_transaction(undo_send_tx.raw_hex())?;
+        .send_raw_transaction(&undo_send_tx)?
+        .txid()?;
     env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -206,9 +217,7 @@ pub fn chained_mempool_tx_sync() -> anyhow::Result<()> {
     let rpc_client = env.rpc_client();
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
 
-    let tracked_addr = rpc_client
-        .get_new_address(None, None)?
-        .require_network(Network::Regtest)?;
+    let tracked_addr = rpc_client.new_address()?;
 
     env.mine_blocks(100, None)?;
 
@@ -217,32 +226,37 @@ pub fn chained_mempool_tx_sync() -> anyhow::Result<()> {
 
     // Create second unconfirmed tx that spends the first.
     let utxo = rpc_client
-        .list_unspent(None, Some(0), None, Some(true), None)?
+        .list_unspent()?
+        .0
         .into_iter()
-        .find(|utxo| utxo.script_pub_key == tracked_addr.script_pubkey())
-        .expect("must find the newly created utxo");
-    let tx_that_spends_unconfirmed = rpc_client.create_raw_transaction(
-        &[CreateRawTransactionInput {
-            txid: utxo.txid,
-            vout: utxo.vout,
-            sequence: None,
-        }],
-        &[(
-            tracked_addr.to_string(),
-            utxo.amount - Amount::from_sat(1000),
-        )]
-        .into(),
-        None,
-        None,
-    )?;
-    let signed_tx = rpc_client
-        .sign_raw_transaction_with_wallet(tx_that_spends_unconfirmed.raw_hex(), None, None)?
+        .find(|utxo| utxo.script_pubkey == tracked_addr.script_pubkey().to_string())
+        .expect("must find the newly created utxo")
+        .into_model()?;
+    let tx_that_spends_unconfirmed = rpc_client
+        .create_raw_transaction(
+            &[Input {
+                txid: utxo.txid,
+                vout: utxo.vout as u64,
+                sequence: None,
+            }],
+            &[Output::new(
+                tracked_addr.clone(),
+                utxo.amount.to_unsigned()? - Amount::from_sat(1000),
+            )],
+        )?
         .transaction()?;
-    let txid2 = rpc_client.send_raw_transaction(signed_tx.raw_hex())?;
+    let signed_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&tx_that_spends_unconfirmed)?
+        .into_model()?
+        .tx;
+
+    let txid2 = rpc_client.send_raw_transaction(&signed_tx)?.txid()?;
 
     env.wait_until_electrum_sees_txid(signed_tx.compute_txid(), Duration::from_secs(6))?;
 
-    let spk_history = electrum_client.script_get_history(&tracked_addr.script_pubkey())?;
+    let spk = tracked_addr.clone().script_pubkey();
+    let script = spk.as_script();
+    let spk_history = electrum_client.script_get_history(script)?;
     assert!(
         spk_history.into_iter().any(|tx_res| tx_res.height < 0),
         "must find tx with negative height"
@@ -280,26 +294,16 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     ];
 
     let _block_hashes = env.mine_blocks(101, None)?;
-    let txid1 = env.bitcoind.client.send_to_address(
-        &receive_address1,
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
-    let txid2 = env.bitcoind.client.send_to_address(
-        &receive_address0,
-        Amount::from_sat(20000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid1 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address1, Amount::from_sat(10000))?
+        .txid()?;
+    let txid2 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address0, Amount::from_sat(20000))?
+        .txid()?;
     env.mine_blocks(1, None)?;
     env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
 
@@ -346,7 +350,8 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.compute_txid(), None)
+            .get_transaction(tx.compute_txid())?
+            .into_model()
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
@@ -402,16 +407,11 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
         .collect();
 
     // Then receive coins on the 4th address.
-    let txid_4th_addr = env.bitcoind.client.send_to_address(
-        &addresses[3],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_4th_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[3], Amount::from_sat(10000))?
+        .txid()?;
     env.mine_blocks(1, None)?;
     env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
 
@@ -446,16 +446,11 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
 
     // Now receive a coin on the last address.
-    let txid_last_addr = env.bitcoind.client.send_to_address(
-        &addresses[addresses.len() - 1],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_last_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[addresses.len() - 1], Amount::from_sat(10000))?
+        .txid()?;
     env.mine_blocks(1, None)?;
     env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
 
@@ -507,16 +502,13 @@ fn test_sync() -> anyhow::Result<()> {
     let client = BdkElectrumClient::new(electrum_client);
 
     // Setup addresses.
-    let addr_to_mine = env
-        .bitcoind
-        .client
-        .get_new_address(None, None)?
-        .assume_checked();
+    let addr_to_mine = env.bitcoind.client.new_address()?;
     let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -619,7 +611,8 @@ fn test_sync() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.txid, None)
+            .get_transaction(tx.txid)?
+            .into_model()
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
@@ -650,16 +643,13 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     let client = BdkElectrumClient::new(electrum_client);
 
     // Setup addresses.
-    let addr_to_mine = env
-        .bitcoind
-        .client
-        .get_new_address(None, None)?
-        .assume_checked();
+    let addr_to_mine = env.bitcoind.client.new_address()?;
     let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -745,7 +735,8 @@ fn test_sync_with_coinbase() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -780,7 +771,8 @@ fn test_check_fee_calculation() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -792,42 +784,35 @@ fn test_check_fee_calculation() -> anyhow::Result<()> {
 
     // Send a preliminary tx such that the new utxo in Core's wallet
     // becomes the input of the next tx
-    let new_addr = env
-        .rpc_client()
-        .get_new_address(None, None)?
-        .assume_checked();
+    let new_addr = env.rpc_client().new_address()?;
     let prev_amt = SEND_AMOUNT + FEE_AMOUNT;
     env.send(&new_addr, prev_amt)?;
-    let prev_block_hash = env.mine_blocks(1, None)?.into_iter().next();
+    let _prev_block_hash = env.mine_blocks(1, None)?.into_iter().next();
 
     let txid = env.send(&addr_to_track, SEND_AMOUNT)?;
 
     // Mine a block to confirm sent tx.
-    let block_hash = env.mine_blocks(1, None)?.into_iter().next();
+    let _block_hash = env.mine_blocks(1, None)?.into_iter().next();
 
     // Look at the tx we just sent, it should have 1 input and 1 output
-    let tx = env
-        .rpc_client()
-        .get_raw_transaction_info(&txid, block_hash.as_ref())?;
-    assert_eq!(tx.vin.len(), 1);
-    assert_eq!(tx.vout.len(), 1);
-    let vin = &tx.vin[0];
-    let prev_txid = vin.txid.unwrap();
-    let vout = vin.vout.unwrap();
+    let tx = env.rpc_client().get_raw_transaction_verbose(txid)?;
+    assert_eq!(tx.inputs.len(), 1);
+    assert_eq!(tx.outputs.len(), 1);
+    let vin = &tx.inputs[0];
+    let prev_txid = Txid::from_str(&vin.txid)?;
+    let vout = vin.vout;
     let outpoint = bdk_chain::bitcoin::OutPoint::new(prev_txid, vout);
 
     // Get the txout of the previous tx
-    let prev_tx = env
-        .rpc_client()
-        .get_raw_transaction_info(&prev_txid, prev_block_hash.as_ref())?;
+    let prev_tx = env.rpc_client().get_raw_transaction_verbose(prev_txid)?;
     let txout = prev_tx
-        .vout
+        .outputs
         .iter()
-        .find(|txout| txout.value == prev_amt)
+        .find(|txout| txout.value == prev_amt.to_btc())
         .unwrap();
-    let script_pubkey = ScriptBuf::from_bytes(txout.script_pub_key.hex.to_vec());
+    let script_pubkey = ScriptBuf::from_hex(&txout.script_pubkey.hex)?;
     let txout = bdk_chain::bitcoin::TxOut {
-        value: txout.value,
+        value: Amount::from_float_in(txout.value, Denomination::Bitcoin)?,
         script_pubkey,
     };
 
@@ -872,12 +857,13 @@ fn test_check_fee_calculation() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.txid, None)
+            .get_transaction(tx.txid)
             .expect("Tx must exist")
             .fee
+            .map(|fee| Amount::from_float_in(fee.abs(), Denomination::BTC))
             .expect("Fee must exist")
-            .abs()
-            .to_sat() as u64;
+            .expect("Amount parsing should succeed")
+            .to_sat();
 
         // Check that the calculated fee matches the fee from the transaction data.
         assert_eq!(fee, Amount::from_sat(tx_fee)); // 1650sat

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -560,7 +560,7 @@ mod test {
         BlockId,
     };
     use bdk_core::{bitcoin, ConfirmationBlockTime};
-    use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+    use bdk_testenv::{anyhow, TestEnv};
     use esplora_client::Builder;
 
     use crate::async_ext::{chain_update, fetch_latest_blocks};
@@ -577,7 +577,7 @@ mod test {
         let env = TestEnv::new()?;
         let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
         let client = Builder::new(base_url.as_str()).build_async()?;
-        let initial_height = env.rpc_client().get_block_count()? as u32;
+        let initial_height = env.rpc_client().get_block_count()?.into_model().0 as u32;
 
         let mine_to = 16;
         let _ = env.mine_blocks((mine_to - initial_height) as usize, None)?;
@@ -673,7 +673,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -713,7 +717,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -518,7 +518,7 @@ mod test {
     use bdk_chain::local_chain::LocalChain;
     use bdk_chain::BlockId;
     use bdk_core::ConfirmationBlockTime;
-    use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+    use bdk_testenv::{anyhow, TestEnv};
     use esplora_client::{BlockHash, Builder};
     use std::collections::{BTreeMap, BTreeSet};
     use std::time::Duration;
@@ -543,7 +543,7 @@ mod test {
         let env = TestEnv::new()?;
         let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
         let client = Builder::new(base_url.as_str()).build_blocking();
-        let initial_height = env.rpc_client().get_block_count()? as u32;
+        let initial_height = env.rpc_client().get_block_count()?.into_model().0 as u32;
 
         let mine_to = 16;
         let _ = env.mine_blocks((mine_to - initial_height) as usize, None)?;
@@ -639,7 +639,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -678,7 +682,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -741,10 +749,10 @@ mod test {
         let env = TestEnv::new()?;
         let blocks = {
             let bitcoind_client = &env.bitcoind.client;
-            assert_eq!(bitcoind_client.get_block_count()?, 1);
+            assert_eq!(bitcoind_client.get_block_count()?.0, 1);
             [
-                (0, bitcoind_client.get_block_hash(0)?),
-                (1, bitcoind_client.get_block_hash(1)?),
+                (0, bitcoind_client.get_block_hash(0)?.block_hash()?),
+                (1, bitcoind_client.get_block_hash(1)?.block_hash()?),
             ]
             .into_iter()
             .chain((2..).zip(env.mine_blocks((TIP_HEIGHT - 1) as usize, None)?))

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -4,11 +4,10 @@ use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_chain::spk_txout::SpkTxOutIndex;
 use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, TxGraph};
 use bdk_esplora::EsploraAsyncExt;
-use bdk_testenv::bitcoincore_rpc::json::CreateRawTransactionInput;
-use bdk_testenv::bitcoincore_rpc::RawTx;
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::corepc_node::{Input, Output};
+use bdk_testenv::{anyhow, TestEnv};
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -30,7 +29,8 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_async()?;
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();
@@ -41,48 +41,61 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
 
     // Select a UTXO to use as an input for constructing our test transactions.
     let selected_utxo = rpc_client
-        .list_unspent(None, None, None, Some(false), None)?
+        .list_unspent()?
+        .0
         .into_iter()
         // Find a block reward tx.
-        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
-        .expect("Must find a block reward UTXO");
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50).to_btc())
+        .expect("Must find a block reward UTXO")
+        .into_model()?;
 
     // Derive the sender's address from the selected UTXO.
-    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_spk = selected_utxo.script_pubkey.clone();
     let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
         .expect("Failed to derive address from UTXO");
 
     // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
-    let inputs = [CreateRawTransactionInput {
+    let inputs = [Input {
         txid: selected_utxo.txid,
-        vout: selected_utxo.vout,
+        vout: selected_utxo.vout as u64,
         sequence: None,
     }];
 
     // Create and sign the `send_tx` that sends funds to the receiver address.
-    let send_tx_outputs = HashMap::from([(
-        receiver_addr.to_string(),
-        selected_utxo.amount - SEND_TX_FEE,
-    )]);
-    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let address = receiver_addr;
+    let value = selected_utxo.amount.to_unsigned()? - SEND_TX_FEE;
+    let send_tx_outputs = Output::new(address, value);
+
     let send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &[send_tx_outputs])?
+        .into_model()?
+        .0;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&send_tx)?
+        .into_model()?
+        .tx;
 
     // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
     // address.
-    let undo_send_outputs = HashMap::from([(
-        sender_addr.to_string(),
-        selected_utxo.amount - UNDO_SEND_TX_FEE,
-    )]);
-    let undo_send_tx =
-        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_outputs = [Output::new(
+        sender_addr,
+        selected_utxo.amount.to_unsigned()? - UNDO_SEND_TX_FEE,
+    )];
     let undo_send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &undo_send_outputs)?
+        .into_model()?
+        .0;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&undo_send_tx)?
+        .into_model()?
+        .tx;
 
     // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
-    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    let send_txid = env
+        .rpc_client()
+        .send_raw_transaction(&send_tx)?
+        .into_model()?
+        .0;
     env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -111,7 +124,8 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     // mempool.
     let undo_send_txid = env
         .rpc_client()
-        .send_raw_transaction(undo_send_tx.raw_hex())?;
+        .send_raw_transaction(&undo_send_tx)?
+        .txid()?;
     env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -155,26 +169,16 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     ];
 
     let _block_hashes = env.mine_blocks(101, None)?;
-    let txid1 = env.bitcoind.client.send_to_address(
-        &receive_address1,
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
-    let txid2 = env.bitcoind.client.send_to_address(
-        &receive_address0,
-        Amount::from_sat(20000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid1 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address1, Amount::from_sat(10000))?
+        .txid()?;
+    let txid2 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address0, Amount::from_sat(20000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().await.unwrap() < 102 {
         sleep(Duration::from_millis(10))
@@ -223,8 +227,9 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.compute_txid(), None)
+            .get_transaction(tx.compute_txid())
             .expect("Tx must exist")
+            .into_model()?
             .fee
             .expect("Fee must exist")
             .abs()
@@ -279,16 +284,11 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
         .collect();
 
     // Then receive coins on the 4th address.
-    let txid_4th_addr = env.bitcoind.client.send_to_address(
-        &addresses[3],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_4th_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[3], Amount::from_sat(10000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().await.unwrap() < 103 {
         sleep(Duration::from_millis(10))
@@ -325,16 +325,11 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
 
     // Now receive a coin on the last address.
-    let txid_last_addr = env.bitcoind.client.send_to_address(
-        &addresses[addresses.len() - 1],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_last_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[addresses.len() - 1], Amount::from_sat(10000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().await.unwrap() < 104 {
         sleep(Duration::from_millis(10))

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -4,11 +4,10 @@ use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_chain::spk_txout::SpkTxOutIndex;
 use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, TxGraph};
 use bdk_esplora::EsploraExt;
-use bdk_testenv::bitcoincore_rpc::json::CreateRawTransactionInput;
-use bdk_testenv::bitcoincore_rpc::RawTx;
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::corepc_node::{Input, Output};
+use bdk_testenv::{anyhow, TestEnv};
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -30,7 +29,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_blocking();
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) =
+        LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?.block_hash()?);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();
@@ -41,48 +41,58 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
 
     // Select a UTXO to use as an input for constructing our test transactions.
     let selected_utxo = rpc_client
-        .list_unspent(None, None, None, Some(false), None)?
+        .list_unspent()?
+        .0
         .into_iter()
         // Find a block reward tx.
-        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
-        .expect("Must find a block reward UTXO");
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50).to_btc())
+        .expect("Must find a block reward UTXO")
+        .into_model()?;
 
     // Derive the sender's address from the selected UTXO.
-    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_spk = selected_utxo.script_pubkey.clone();
     let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
         .expect("Failed to derive address from UTXO");
 
     // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
-    let inputs = [CreateRawTransactionInput {
+    let inputs = [Input {
         txid: selected_utxo.txid,
-        vout: selected_utxo.vout,
+        vout: selected_utxo.vout as u64,
         sequence: None,
     }];
 
     // Create and sign the `send_tx` that sends funds to the receiver address.
-    let send_tx_outputs = HashMap::from([(
-        receiver_addr.to_string(),
-        selected_utxo.amount - SEND_TX_FEE,
-    )]);
-    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx_outputs = [Output::new(
+        receiver_addr,
+        selected_utxo.amount.to_unsigned()? - SEND_TX_FEE,
+    )];
+
     let send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &send_tx_outputs)?
+        .into_model()?
+        .0;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&send_tx)?
+        .into_model()?
+        .tx;
 
     // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
     // address.
-    let undo_send_outputs = HashMap::from([(
-        sender_addr.to_string(),
-        selected_utxo.amount - UNDO_SEND_TX_FEE,
-    )]);
-    let undo_send_tx =
-        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_outputs = [Output::new(
+        sender_addr,
+        selected_utxo.amount.to_unsigned()? - UNDO_SEND_TX_FEE,
+    )];
     let undo_send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &undo_send_outputs)?
+        .into_model()?
+        .0;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&undo_send_tx)?
+        .into_model()?
+        .tx;
 
     // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
-    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    let send_txid = env.rpc_client().send_raw_transaction(&send_tx)?.txid()?;
     env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -111,7 +121,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     // mempool.
     let undo_send_txid = env
         .rpc_client()
-        .send_raw_transaction(undo_send_tx.raw_hex())?;
+        .send_raw_transaction(&undo_send_tx)?
+        .txid()?;
     env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -156,26 +167,16 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     ];
 
     let _block_hashes = env.mine_blocks(101, None)?;
-    let txid1 = env.bitcoind.client.send_to_address(
-        &receive_address1,
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
-    let txid2 = env.bitcoind.client.send_to_address(
-        &receive_address0,
-        Amount::from_sat(20000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid1 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address1, Amount::from_sat(10000))?
+        .txid()?;
+    let txid2 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address0, Amount::from_sat(20000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 102 {
         sleep(Duration::from_millis(10))
@@ -224,16 +225,17 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.compute_txid(), None)
+            .get_transaction(tx.compute_txid())
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
-            .abs()
-            .to_unsigned()
-            .expect("valid `Amount`");
+            .abs();
 
         // Check that the calculated fee matches the fee from the transaction data.
-        assert_eq!(fee, tx_fee);
+        assert_eq!(
+            fee,
+            Amount::from_float_in(tx_fee, bdk_core::bitcoin::Denomination::Bitcoin)?
+        );
     }
 
     assert_eq!(
@@ -280,16 +282,12 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
         .collect();
 
     // Then receive coins on the 4th address.
-    let txid_4th_addr = env.bitcoind.client.send_to_address(
-        &addresses[3],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_4th_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[3], Amount::from_sat(10000))?
+        .into_model()?
+        .txid;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 103 {
         sleep(Duration::from_millis(10))
@@ -326,16 +324,11 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
 
     // Now receive a coin on the last address.
-    let txid_last_addr = env.bitcoind.client.send_to_address(
-        &addresses[addresses.len() - 1],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_last_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[addresses.len() - 1], Amount::from_sat(10000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 104 {
         sleep(Duration::from_millis(10))

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -17,14 +17,14 @@ workspace = true
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
-electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
+electrsd = { version = "0.35.0", features = [ "legacy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }
 
 [features]
 default = ["std", "download"]
-download = ["electrsd/bitcoind_25_0", "electrsd/esplora_a33e97e1"]
+download = ["electrsd/corepc-node_28_1", "electrsd/esplora_a33e97e1"]
 std = ["bdk_chain/std"]
 serde = ["bdk_chain/serde"]
 

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -10,24 +10,20 @@ use bdk_chain::{
     },
     local_chain::CheckPoint,
 };
-use bitcoincore_rpc::{
-    bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateRules},
-    RpcApi,
-};
-use electrsd::bitcoind::anyhow::Context;
+use electrsd::corepc_node::{anyhow::Context, TemplateRequest, TemplateRules};
 
 pub use electrsd;
-pub use electrsd::bitcoind;
-pub use electrsd::bitcoind::anyhow;
-pub use electrsd::bitcoind::bitcoincore_rpc;
+pub use electrsd::corepc_client;
+pub use electrsd::corepc_node;
+pub use electrsd::corepc_node::anyhow;
 pub use electrsd::electrum_client;
 use electrsd::electrum_client::ElectrumApi;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 /// Struct for running a regtest environment with a single `bitcoind` node with an `electrs`
 /// instance connected to it.
 pub struct TestEnv {
-    pub bitcoind: electrsd::bitcoind::BitcoinD,
+    pub bitcoind: electrsd::corepc_node::Node,
     pub electrsd: electrsd::ElectrsD,
 }
 
@@ -35,7 +31,7 @@ pub struct TestEnv {
 #[derive(Debug)]
 pub struct Config<'a> {
     /// [`bitcoind::Conf`]
-    pub bitcoind: bitcoind::Conf<'a>,
+    pub bitcoind: corepc_node::Conf<'a>,
     /// [`electrsd::Conf`]
     pub electrsd: electrsd::Conf<'a>,
 }
@@ -45,7 +41,7 @@ impl Default for Config<'_> {
     /// which is required for testing `bdk_esplora`.
     fn default() -> Self {
         Self {
-            bitcoind: bitcoind::Conf::default(),
+            bitcoind: corepc_node::Conf::default(),
             electrsd: {
                 let mut conf = electrsd::Conf::default();
                 conf.http_enabled = true;
@@ -65,11 +61,11 @@ impl TestEnv {
     pub fn new_with_config(config: Config) -> anyhow::Result<Self> {
         let bitcoind_exe = match std::env::var("BITCOIND_EXE") {
             Ok(path) => path,
-            Err(_) => bitcoind::downloaded_exe_path().context(
+            Err(_) => corepc_node::downloaded_exe_path().context(
                 "you need to provide an env var BITCOIND_EXE or specify a bitcoind version feature",
             )?,
         };
-        let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &config.bitcoind)?;
+        let bitcoind = corepc_node::Node::with_conf(bitcoind_exe, &config.bitcoind)?;
 
         let electrs_exe = match std::env::var("ELECTRS_EXE") {
             Ok(path) => path,
@@ -87,7 +83,7 @@ impl TestEnv {
     }
 
     /// Exposes the [`RpcApi`] calls from [`bitcoincore_rpc`].
-    pub fn rpc_client(&self) -> &impl RpcApi {
+    pub fn rpc_client(&self) -> &corepc_node::Client {
         &self.bitcoind.client
     }
 
@@ -118,26 +114,23 @@ impl TestEnv {
     ) -> anyhow::Result<Vec<BlockHash>> {
         let coinbase_address = match address {
             Some(address) => address,
-            None => self
-                .bitcoind
-                .client
-                .get_new_address(None, None)?
-                .assume_checked(),
+            None => self.bitcoind.client.new_address()?,
         };
         let block_hashes = self
             .bitcoind
             .client
-            .generate_to_address(count as _, &coinbase_address)?;
+            .generate_to_address(count as _, &coinbase_address)?
+            .into_model()?
+            .0;
         Ok(block_hashes)
     }
 
     /// Mine a block that is guaranteed to be empty even with transactions in the mempool.
     pub fn mine_empty_block(&self) -> anyhow::Result<(usize, BlockHash)> {
-        let bt = self.bitcoind.client.get_block_template(
-            GetBlockTemplateModes::Template,
-            &[GetBlockTemplateRules::SegWit],
-            &[],
-        )?;
+        let request = TemplateRequest {
+            rules: vec![TemplateRules::Segwit],
+        };
+        let bt = self.bitcoind.client.get_block_template(&request)?;
 
         let txdata = vec![Transaction {
             version: transaction::Version::ONE,
@@ -146,7 +139,7 @@ impl TestEnv {
                 previous_output: bdk_chain::bitcoin::OutPoint::default(),
                 script_sig: ScriptBuf::builder()
                     .push_int(bt.height as _)
-                    // randomn number so that re-mining creates unique block
+                    // random number so that re-mining creates unique block
                     .push_int(random())
                     .into_script(),
                 sequence: bdk_chain::bitcoin::Sequence::default(),
@@ -158,18 +151,22 @@ impl TestEnv {
             }],
         }];
 
-        let bits: [u8; 4] = bt
-            .bits
-            .clone()
-            .try_into()
-            .expect("rpc provided us with invalid bits");
+        // TODO: (@leonardo) double-check if an `.into_bytes()` wouldn't be enough instead.
+        let bits: [u8; 4] =
+            bdk_chain::bitcoin::consensus::encode::deserialize_hex::<Vec<u8>>(&bt.bits)?
+                .clone()
+                .try_into()
+                .expect("rpc provided us with invalid bits");
 
         let mut block = Block {
             header: Header {
                 version: bdk_chain::bitcoin::block::Version::default(),
-                prev_blockhash: bt.previous_block_hash,
+                prev_blockhash: BlockHash::from_str(&bt.previous_block_hash)?,
                 merkle_root: TxMerkleNode::all_zeros(),
-                time: Ord::max(bt.min_time, std::time::UNIX_EPOCH.elapsed()?.as_secs()) as u32,
+                time: Ord::max(
+                    bt.min_time,
+                    std::time::UNIX_EPOCH.elapsed()?.as_secs() as u32,
+                ),
                 bits: CompactTarget::from_consensus(u32::from_be_bytes(bits)),
                 nonce: 0,
             },
@@ -186,6 +183,7 @@ impl TestEnv {
         }
 
         self.bitcoind.client.submit_block(&block)?;
+
         Ok((bt.height as usize, block.block_hash()))
     }
 
@@ -238,18 +236,16 @@ impl TestEnv {
 
     /// Invalidate a number of blocks of a given size `count`.
     pub fn invalidate_blocks(&self, count: usize) -> anyhow::Result<()> {
-        let mut hash = self.bitcoind.client.get_best_block_hash()?;
+        let mut hash = self.bitcoind.client.get_best_block_hash()?.block_hash()?;
         for _ in 0..count {
-            let prev_hash = self
-                .bitcoind
-                .client
-                .get_block_info(&hash)?
-                .previousblockhash;
-            self.bitcoind.client.invalidate_block(&hash)?;
-            match prev_hash {
-                Some(prev_hash) => hash = prev_hash,
-                None => break,
-            }
+            let prev_hash = self.bitcoind.client.get_block(hash)?.header.prev_blockhash;
+            self.bitcoind.client.invalidate_block(hash)?;
+            hash = prev_hash
+            // TODO: (@leonardo) It requires a double check if there is any side-effect with this
+            // break removal. match prev_hash {
+            //     Some(prev_hash) => hash = prev_hash,
+            //     None => break,
+            // }
         }
         Ok(())
     }
@@ -290,7 +286,8 @@ impl TestEnv {
         let txid = self
             .bitcoind
             .client
-            .send_to_address(address, amount, None, None, None, None, None, None)?;
+            .send_to_address(address, amount)?
+            .txid()?;
         Ok(txid)
     }
 
@@ -301,14 +298,19 @@ impl TestEnv {
                 .client
                 .get_block_hash(height as u64)
                 .ok()
-                .map(|hash| (height, hash))
+                .map(|get_block_hash| {
+                    let hash = get_block_hash
+                        .block_hash()
+                        .expect("should `successfully convert to `BlockHash` from `GetBlockHash`");
+                    (height, hash)
+                })
         }))
         .expect("must craft tip")
     }
 
     /// Get the genesis hash of the blockchain.
     pub fn genesis_hash(&self) -> anyhow::Result<BlockHash> {
-        let hash = self.bitcoind.client.get_block_hash(0)?;
+        let hash = self.bitcoind.client.get_block_hash(0)?.into_model()?.0;
         Ok(hash)
     }
 }
@@ -318,7 +320,7 @@ impl TestEnv {
 mod test {
     use crate::TestEnv;
     use core::time::Duration;
-    use electrsd::bitcoind::{anyhow::Result, bitcoincore_rpc::RpcApi};
+    use electrsd::corepc_node::anyhow::Result;
 
     /// This checks that reorgs initiated by `bitcoind` is detected by our `electrsd` instance.
     #[test]
@@ -328,7 +330,7 @@ mod test {
         // Mine some blocks.
         env.mine_blocks(101, None)?;
         env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
-        let height = env.bitcoind.client.get_block_count()?;
+        let height = env.bitcoind.client.get_block_count()?.into_model().0;
         let blocks = (0..=height)
             .map(|i| env.bitcoind.client.get_block_hash(i))
             .collect::<Result<Vec<_>, _>>()?;
@@ -336,7 +338,7 @@ mod test {
         // Perform reorg on six blocks.
         env.reorg(6)?;
         env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
-        let reorged_height = env.bitcoind.client.get_block_count()?;
+        let reorged_height = env.bitcoind.client.get_block_count()?.into_model().0;
         let reorged_blocks = (0..=height)
             .map(|i| env.bitcoind.client.get_block_hash(i))
             .collect::<Result<Vec<_>, _>>()?;


### PR DESCRIPTION
The `common` module introduces `ClientExt` trait for easily creating a RPC client of the type that is expected by the core library code.